### PR TITLE
Support for smaller then sign

### DIFF
--- a/Assets/RichTextHelper/RichTextHelper.cs
+++ b/Assets/RichTextHelper/RichTextHelper.cs
@@ -17,6 +17,7 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 //  DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -68,6 +69,8 @@ namespace RichTextSubstringHelper
         private Stack<RichTextTag> tagStack;
         private int consumedLength;
 
+        private static readonly char[] tagBrackets = new char[2] { '<', '>' };
+
         public RichTextSubStringMaker(string original)
         {
             this.originalText = original;
@@ -111,10 +114,16 @@ namespace RichTextSubstringHelper
                 {
                     ConsumeEndTag();
                 }
-                else
+                else if (IsNextTagBracketClosing(consumedLength + 1))   //Only consume the start tag if a tag closing bracket (>) was found.
                 {
                     ConsumeStartTag();
                 }
+                else
+                {
+                    ConsumeRawChar();
+                    return true;
+                }
+
                 if (IsConsumable())
                 {
                     Consume();
@@ -144,6 +153,14 @@ namespace RichTextSubstringHelper
         private char PeekNextOriginChar()
         {
             return originalText[consumedLength];
+        }
+
+        //Returns if the first tag bracket found in the string is '>', as opposed to '<'
+        private bool IsNextTagBracketClosing(int charIndexToStartSearch = 0)
+        {
+            int bracketIndex = originalText.IndexOfAny(tagBrackets, charIndexToStartSearch);
+
+            return bracketIndex != -1 && originalText[bracketIndex] == '>';
         }
 
         private void ConsumeStartTag()

--- a/Assets/test/RichTextHelperTest.cs
+++ b/Assets/test/RichTextHelperTest.cs
@@ -63,4 +63,32 @@ public class RichTextHelperTest
         Assert.AreEqual(sampleTagText.RichTextSubString(3), "<color=#000>a<i>b<b>c</b></i></color>");
         Assert.AreEqual(sampleTagText.RichTextSubString(4), "<color=#000>a<i>b<b>c</b>d</i></color>");
     }
+
+    [Test]
+    public void SmallerThenSignWithoutTag()
+    {
+        var sampleTagText = "<--<color=#000>l</color><i>r</i>-->";
+        Assert.AreEqual(sampleTagText.RichTextSubString(8), sampleTagText);
+        Assert.AreEqual(sampleTagText.RichTextSubString(1), "<");
+        Assert.AreEqual(sampleTagText.RichTextSubString(2), "<-");
+        Assert.AreEqual(sampleTagText.RichTextSubString(3), "<--");
+        Assert.AreEqual(sampleTagText.RichTextSubString(4), "<--<color=#000>l</color>");
+        Assert.AreEqual(sampleTagText.RichTextSubString(5), "<--<color=#000>l</color><i>r</i>");
+        Assert.AreEqual(sampleTagText.RichTextSubString(6), "<--<color=#000>l</color><i>r</i>-");
+        Assert.AreEqual(sampleTagText.RichTextSubString(7), "<--<color=#000>l</color><i>r</i>--");
+
+        var sampleTagText2 = "<a<b<c<color=#000><</color><i>><</i>><<";
+        Assert.AreEqual(sampleTagText2.RichTextSubString(12), sampleTagText2);
+        Assert.AreEqual(sampleTagText2.RichTextSubString(1), "<");
+        Assert.AreEqual(sampleTagText2.RichTextSubString(2), "<a");
+        Assert.AreEqual(sampleTagText2.RichTextSubString(3), "<a<");
+        Assert.AreEqual(sampleTagText2.RichTextSubString(4), "<a<b");
+        Assert.AreEqual(sampleTagText2.RichTextSubString(5), "<a<b<");
+        Assert.AreEqual(sampleTagText2.RichTextSubString(6), "<a<b<c");
+        Assert.AreEqual(sampleTagText2.RichTextSubString(7), "<a<b<c<color=#000><</color>");
+        Assert.AreEqual(sampleTagText2.RichTextSubString(8), "<a<b<c<color=#000><</color><i>></i>");
+        Assert.AreEqual(sampleTagText2.RichTextSubString(9), "<a<b<c<color=#000><</color><i>><</i>");
+        Assert.AreEqual(sampleTagText2.RichTextSubString(10), "<a<b<c<color=#000><</color><i>><</i>>");
+        Assert.AreEqual(sampleTagText2.RichTextSubString(11), "<a<b<c<color=#000><</color><i>><</i>><");
+    }
 }


### PR DESCRIPTION
Added support for smaller then sign in text, without this being considered a tag starting bracket.